### PR TITLE
make release-chart run dependant release-image

### DIFF
--- a/src/amazon-s3/Makefile
+++ b/src/amazon-s3/Makefile
@@ -15,7 +15,7 @@ release-image:
 	# Build and push multi-arch manifest.
 	docker buildx build --push --tag $(IMAGE):$(IMAGE_TAG) --platform $(PLATFORMS) .
 
-release-chart:
+release-chart: release-image
 	# Copy latest Helm chart into the directory tree that gets auto-published.
 	rm -rf $(CHART_ROOT)/$(NAME)
 	mkdir $(CHART_ROOT)/$(NAME)

--- a/src/amazon-sqs/Makefile
+++ b/src/amazon-sqs/Makefile
@@ -15,7 +15,7 @@ release-image:
 	# Build and push multi-arch manifest.
 	docker buildx build --push --tag $(IMAGE):$(IMAGE_TAG) --platform $(PLATFORMS) .
 
-release-chart:
+release-chart: release-image
 	# Copy latest Helm chart into the directory tree that gets auto-published.
 	rm -rf $(CHART_ROOT)/$(NAME)
 	mkdir $(CHART_ROOT)/$(NAME)

--- a/src/mariadb/Makefile
+++ b/src/mariadb/Makefile
@@ -15,7 +15,7 @@ release-image:
 	# Build and push multi-arch manifest.
 	docker buildx build --push --tag $(IMAGE):$(IMAGE_TAG) --platform $(PLATFORMS) .
 
-release-chart:
+release-chart: release-image
 	# Copy latest Helm chart into the directory tree that gets auto-published.
 	rm -rf $(CHART_ROOT)/$(NAME)
 	mkdir $(CHART_ROOT)/$(NAME)

--- a/src/postgres/Makefile
+++ b/src/postgres/Makefile
@@ -15,7 +15,7 @@ release-image:
 	# Build and push multi-arch manifest.
 	docker buildx build --push --tag $(IMAGE):$(IMAGE_TAG) --platform $(PLATFORMS) .
 
-release-chart:
+release-chart: release-image
 	# Copy latest Helm chart into the directory tree that gets auto-published.
 	rm -rf $(CHART_ROOT)/$(NAME)
 	mkdir $(CHART_ROOT)/$(NAME)

--- a/src/rabbitmq/Makefile
+++ b/src/rabbitmq/Makefile
@@ -15,7 +15,7 @@ release-image:
 	# Build and push multi-arch manifest.
 	docker buildx build --push --tag $(IMAGE):$(IMAGE_TAG) --platform $(PLATFORMS) .
 
-release-chart:
+release-chart: release-image
 	# Copy latest Helm chart into the directory tree that gets auto-published.
 	rm -rf $(CHART_ROOT)/$(NAME)
 	mkdir $(CHART_ROOT)/$(NAME)


### PR DESCRIPTION
Looks like make release chart was run without make release-images => reflect the dependency in the makefiles.
