### PR TITLE
Include README.md as description

### DIFF
--- a/amazon-sqs/plugin.yaml
+++ b/amazon-sqs/plugin.yaml
@@ -1,17 +1,6 @@
 name: amazon-sqs
 spec:
-  description: |
-    Provision a temporary queue in Amazon SQS for use within a sandbox.
-
-    Each sandbox resource request must specify a 'region' parameter,
-    indicating the AWS region in which to provision the queue (e.g. us-east-1).
-
-    Each sandbox resource request can optionally specify 'attributes' and 'tags'
-    that will be passed to the corresponding flags in the 'aws sqs create-queue'
-    command: https://docs.aws.amazon.com/cli/latest/reference/sqs/create-queue.html
-
-    The temporary queue name will be available as the output key 'queue-name',
-    and the queue URL will be available as the key 'queue-url'.
+  description: "@{embed: README.md}"
 
   runner:
     image: amazon/aws-cli

--- a/mariadb/plugin.yaml
+++ b/mariadb/plugin.yaml
@@ -1,11 +1,6 @@
 name: mariadb
 spec:
-  description: |
-    Provision a MariaDB instance
-
-    Sandbox should provide input 'dbname' for the name of the database.
-    Plugin provisioner provides outputs 'host', 'port', 'root-password' for 
-    an empty database instance tied to the lifetime of the sandbox.
+  description: "@{embed: README.md}"
 
   runner:
     image: dtzar/helm-kubectl

--- a/postgres-vault/plugin.yaml
+++ b/postgres-vault/plugin.yaml
@@ -1,7 +1,6 @@
 name: postgres-vault
 spec:
-  description: |
-    Provision and seed a postgres database from a postgres service.
+  description: "@{embed: README.md}"
 
   runner:
     image: postgres

--- a/terraform/plugin.yaml
+++ b/terraform/plugin.yaml
@@ -1,8 +1,6 @@
 name: terraform
 spec:
-  description: |
-    This is a sample terraform script that provisions a temporary Amazon S3
-    bucket for use within a sandbox.
+  description: "@{embed: README.md}"
 
   runner:
     image: hashicorp/terraform:1.4.2


### PR DESCRIPTION
It's much easier to include description about the plugin in a markdown than in the spec itself. If we plumb it this way, it's more likely that the customers will follow the same.

Open to opinion.